### PR TITLE
Unnecessary git package add is triggering policy failures

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,7 +16,7 @@
 FROM mhart/alpine-node:11.12
 RUN apk update
 RUN apk upgrade
-RUN apk add bash git
+RUN apk add bash
 WORKDIR /app/frontend
 COPY ./package.json /app/frontend/package.json
 COPY ./yarn.lock /app/frontend/yarn.lock

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -16,7 +16,7 @@
 FROM mhart/alpine-node:11.12 as builder
 RUN apk update
 RUN apk upgrade
-RUN apk add bash git
+RUN apk add bash
 WORKDIR /app/frontend
 COPY ./package.json /app/frontend/package.json
 COPY ./yarn.lock /app/frontend/yarn.lock


### PR DESCRIPTION
git is triggering a vulnerability scan alert, and probably shouldn't be there in the first place.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>